### PR TITLE
support go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x, 1.18.x]
+        golangcilint-version: [1.45.2]
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -21,8 +22,8 @@ jobs:
 
     - name: Get go toolchains
       run: |
-        go get -u golang.org/x/lint/golint
-        sudo cp $GOPATH/bin/golint /usr/bin/
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v${{ matrix.golangcilint-version }}
+        sudo cp $GOPATH/bin/golangci-lint /usr/bin/
       env:
         GOPATH: /home/runner/work/sesstok/go
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,14 +3,17 @@ on: [push]
 jobs:
 
   build:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.18.x]
     name: Test
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: ${{ matrix.go-version }}
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 	go test -v -race ./...
 
 lint:
-	golint -set_exit_status $(PKGS)
+	golangci-lint run -v
 
 vet:
 	go vet $(PKGS)

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190909091759-094676da4a83
+	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 h1:kHVeDEnfKn3T238CvrUcz6KeEsFHVaKh4kMTt6Wsysg=
+golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/internal/options.go
+++ b/internal/options.go
@@ -69,7 +69,7 @@ func NewOptionsParser() *OptionsParser {
 
 // ParseArgs parses the CLI arguments and converts that to the Options.
 func (p *OptionsParser) ParseArgs(args []string) (*Options, error) {
-	args, err := p.parser.ParseArgs(args)
+	_, err := p.parser.ParseArgs(args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

Before anything else, thank you for creating the tool, which helps my daily tasks a lot. :)
When I switched to go 1.18. I failed to install sesstok on darwin/arm64 as follows.

```console
❯ go version
go version go1.18 darwin/arm64

❯ go install github.com/moznion/sesstok/cmd/sesstok@latest
# golang.org/x/sys/unix
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:136:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:151:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:166:3: //go:linkname must refer to declared function or variable
../../../../1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190412213103-97732733099d/unix/zsyscall_darwin_arm64.go:166:3: too many errors
```

To fix the above issue, I just bumped `golang.org/x/sys` and added some minor fixes.

#### Additional documentation
I found similar issue [here](https://github.com/golang/go/issues/51091#issuecomment-1033334340).